### PR TITLE
Use getopt instead of Boost program options

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: etr/libhttpserver
-        ref: 0.18.2
+        ref: 0.19.0
         path: libhttpserver
 
     - name: Install Python dependencies

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,7 +29,7 @@ jobs:
       uses: py-actions/py-dependency-install@v4
 
     - name: Install C++ dependencies
-      run: sudo apt-get install -y libboost-program-options-dev libmicrohttpd-dev libfmt-dev pybind11-dev
+      run: sudo apt-get install -y libmicrohttpd-dev libfmt-dev pybind11-dev
 
     - name: Build and install libhttpserver
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
 list(APPEND CMAKE_MODULE_PATH "/usr/local/share/cmake/Modules")
 
 find_package(Python COMPONENTS Interpreter Development)
-find_package(Boost REQUIRED program_options)
 find_package(fmt REQUIRED)
 find_package(LibHttpServer MODULE REQUIRED)
 find_package(pybind11 REQUIRED)
@@ -20,7 +19,7 @@ find_package(pybind11 REQUIRED)
 include(CTest)
 
 add_executable(tuberd src/server.cpp)
-target_link_libraries(tuberd PRIVATE boost_program_options fmt::fmt httpserver pybind11::embed)
+target_link_libraries(tuberd PRIVATE fmt::fmt httpserver pybind11::embed)
 
 pybind11_add_module(test_module MODULE tests/test_module.cpp)
 target_include_directories(test_module PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(pybind11 REQUIRED)
 include(CTest)
 
 add_executable(tuberd src/server.cpp)
-target_link_libraries(tuberd PRIVATE fmt::fmt httpserver pybind11::embed)
+target_link_libraries(tuberd PRIVATE fmt::fmt ${LIBHTTPSERVER_LIBRARIES} pybind11::embed)
 
 pybind11_add_module(test_module MODULE tests/test_module.cpp)
 target_include_directories(test_module PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -365,9 +365,9 @@ static void sigint(int signo) {
 
 /* pretty print CLI options */
 #define PRINTOPT(o, h) \
-  "  " << o << "\n      " << h << "\n"
+  fmt::print("  {}\n      {}\n", o, h)
 #define PRINTOPT2(o, h, d) \
-  "  " << o << "\n      " << h << " (default: " << d << ")\n"
+  fmt::print("  {}\n      {} (default: {})\n", o, h, d)
 
 int main(int argc, char **argv) {
 	/*
@@ -427,23 +427,23 @@ int main(int argc, char **argv) {
 		case 'h':
 		case '?':
 		default:
-			std::cout << "Usage: " << argv[0] << " [options]\n\nOptions:\n"
-			    << PRINTOPT("-h [ --help ]", "produce help message")
-			    << PRINTOPT2("--max-age N",
-			    "maximum cache residency for static (file) assets", max_age)
-			    << PRINTOPT2("-j [ --json ] NAME",
+			fmt::print("Usage: {} [options]\n\nOptions:\n", argv[0]);
+			PRINTOPT("-h [ --help ]", "produce help message");
+			PRINTOPT2("--max-age N",
+			    "maximum cache residency for static (file) assets", max_age);
+			PRINTOPT2("-j [ --json ] NAME",
 			    "Python JSON module to use for serialization/deserialization",
-			    json_module)
-			    << PRINTOPT("--orjson-with-numpy",
-			    "use ORJSON module with fast NumPy serialization support")
-			    << PRINTOPT2("-p [ --port ] PORT", "port", port)
-			    << PRINTOPT2("--preamble PATH",
-			    "location of slow-path Python code", preamble)
-			    << PRINTOPT2("--registry PATH",
-			    "location of registry Python code", registry)
-			    << PRINTOPT2("-w [ --webroot ] PATH",
-			    "location to serve static content", webroot)
-			    << PRINTOPT2("-v [ --verbose ] N", "verbosity", (int)verbose);
+			    json_module);
+			PRINTOPT("--orjson-with-numpy",
+			    "use ORJSON module with fast NumPy serialization support");
+			PRINTOPT2("-p [ --port ] PORT", "port", port);
+			PRINTOPT2("--preamble PATH", "location of slow-path Python code",
+			    preamble);
+			PRINTOPT2("--registry PATH", "location of registry Python code",
+			    registry);
+			PRINTOPT2("-w [ --webroot ] PATH",
+			    "location to serve static content", webroot);
+			PRINTOPT2("-v [ --verbose ] N", "verbosity", (int)verbose);
 			return 1;
 		}
 	}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -221,7 +221,7 @@ class DLL_LOCAL tuber_resource : public http_resource {
 			json_loads(json_loads),
 			json_dumps(json_dumps) {};
 
-		const std::shared_ptr<http_response> render(const http_request& req) {
+		std::shared_ptr<http_response> render(const http_request& req) {
 			/* Acquire the GIL. This makes us thread-safe -
 			 * but any methods we invoke should release the
 			 * GIL (especially if they do their own
@@ -234,7 +234,8 @@ class DLL_LOCAL tuber_resource : public http_resource {
 					fmt::print(stderr, "Request: {}\n", req.get_content());
 
 				/* Parse JSON */
-				py::object request_obj = json_loads(req.get_content());
+				std::string content(req.get_content());
+				py::object request_obj = json_loads(content);
 
 				if(py::isinstance<py::dict>(request_obj)) {
 					/* Simple JSON object - invoke it and return the results. */
@@ -312,7 +313,7 @@ class DLL_LOCAL file_resource : public http_resource {
 	public:
 		file_resource(fs::path webroot, int max_age) : webroot(webroot), max_age(max_age) {};
 
-		const std::shared_ptr<http_response> render_GET(const http_request& req) {
+		std::shared_ptr<http_response> render_GET(const http_request& req) {
 			/* Start with webroot and append path segments from
 			 * HTTP request.
 			 *

--- a/tests/test_module.cpp
+++ b/tests/test_module.cpp
@@ -18,7 +18,8 @@ class Wrapper {
 		bool is_y(Kind const& k) const { return k == Kind::Y; }
 
 		std::vector<int> increment(std::vector<int> x) {
-			std::ranges::for_each(x, [](int &n) { n++; });
+			for (auto &i : x)
+				i++;
 			return x;
 		};
 };


### PR DESCRIPTION
This removes the sole dependency on Boost, making it easier to install on lightweight systems.