### PR TITLE
Various compatibility fixes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: etr/libhttpserver
-        ref: 0.18.2
+        ref: 0.19.0
         path: libhttpserver
 
     - name: Install Python dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(pybind11 REQUIRED)
 include(CTest)
 
 add_executable(tuberd src/server.cpp)
-target_link_libraries(tuberd PRIVATE boost_program_options fmt::fmt httpserver pybind11::embed)
+target_link_libraries(tuberd PRIVATE Boost::program_options fmt::fmt ${LIBHTTPSERVER_LIBRARIES} pybind11::embed)
 
 pybind11_add_module(test_module MODULE tests/test_module.cpp)
 target_include_directories(test_module PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -222,7 +222,7 @@ class DLL_LOCAL tuber_resource : public http_resource {
 			json_loads(json_loads),
 			json_dumps(json_dumps) {};
 
-		const std::shared_ptr<http_response> render(const http_request& req) {
+		std::shared_ptr<http_response> render(const http_request& req) {
 			/* Acquire the GIL. This makes us thread-safe -
 			 * but any methods we invoke should release the
 			 * GIL (especially if they do their own
@@ -235,7 +235,8 @@ class DLL_LOCAL tuber_resource : public http_resource {
 					fmt::print(stderr, "Request: {}\n", req.get_content());
 
 				/* Parse JSON */
-				py::object request_obj = json_loads(req.get_content());
+				std::string content(req.get_content());
+				py::object request_obj = json_loads(content);
 
 				if(py::isinstance<py::dict>(request_obj)) {
 					/* Simple JSON object - invoke it and return the results. */
@@ -313,7 +314,7 @@ class DLL_LOCAL file_resource : public http_resource {
 	public:
 		file_resource(fs::path webroot, int max_age) : webroot(webroot), max_age(max_age) {};
 
-		const std::shared_ptr<http_response> render_GET(const http_request& req) {
+		std::shared_ptr<http_response> render_GET(const http_request& req) {
 			/* Start with webroot and append path segments from
 			 * HTTP request.
 			 *

--- a/tests/test_module.cpp
+++ b/tests/test_module.cpp
@@ -18,7 +18,8 @@ class Wrapper {
 		bool is_y(Kind const& k) const { return k == Kind::Y; }
 
 		std::vector<int> increment(std::vector<int> x) {
-			std::ranges::for_each(x, [](int &n) { n++; });
+			for (auto &i : x)
+				i++;
 			return x;
 		};
 };


### PR DESCRIPTION
This PR introduces a few compatibility fixes, found while attempting to compile the library on an OSX 12.7.3 system with Apple Clang 14.0.0, linking against libhttpserver 0.19.0.

* Update github workflow to latest libhttpserver version
* Fix linking against Boost and libhttpserver libraries
* Fix return value for `render()` and `render_GET()` methods of the `file_resource` class (libhttpserver 0.19.0 dropped the const modifier)
* Fix parsing of returned content (libhttpserver 0.19.0 uses `std::string_view` here)
* Use a C++11-style for-loop in test suite to avoid errors on systems without the C++20 STL.