### PR TITLE
Release the GIL after initializing tuber_resource

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -506,8 +506,6 @@ int main(int argc, char **argv) {
 	/* Create a registry */
 	py::dict reg = py::eval("registry");
 
-	py::gil_scoped_release release;
-
 	/*
 	 * Start webserver
 	 */
@@ -523,6 +521,8 @@ int main(int argc, char **argv) {
 	tr->disallow_all();
 	tr->set_allowing(MHD_HTTP_METHOD_POST, true);
 	ws->register_resource("/tuber", tr.get());
+
+	py::gil_scoped_release release;
 
 	/* If a valid webroot was provided, serve static content for other paths. */
 	try {


### PR DESCRIPTION
This avoids a `PyGILState_Check()` failure when `inc_ref()` is called on the imported registry object.