### PR TITLE
Attempt to clean up asyncio.ClientSession objects

### DIFF
--- a/py/tuber/tuber.py
+++ b/py/tuber/tuber.py
@@ -39,6 +39,19 @@ async def resolve(objname: str, hostname: str):
 _clientsession: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
 
+# Normally, asyncio.ClientSessions in _clientsession are automatically garbage
+# collected when their event loops close. Sometimes that doesn't happen
+# (notably, in ipython) and an extra tidy-up step ensures no warnings when we
+# exit.
+def cleanup():
+    for l, cs in _clientsession.items():
+        if not l.is_closed():
+            l.call_soon(cs.close)
+
+
+atexit.register(cleanup)
+
+
 class TuberError(Exception):
     pass
 


### PR DESCRIPTION
The global cache (with WeakKeyDictionary) is not sufficient for ipython, for some reason. This change is a little simplistic (for example, we do see closed event loops and are hence unable to trigger close() calls on captive ClientSessions).

@arahlin's more complete option can be found in pone-software/perseus, and is a little longer, a little more intrusive, but doesn't cut corners. We may end up adopting it if this doesn't survive a little testing.