### PR TITLE
Implement CBOR as an optional alternative transport format

### DIFF
--- a/py/preamble.py
+++ b/py/preamble.py
@@ -4,6 +4,8 @@ import os
 import sysconfig
 import site
 
+from tuber.codecs import wrap_bytes_for_json, cbor_augment_encode, cbor_tag_decode
+
 
 # Although upstream pybind11 allows user sites (check site.ENABLE_USER_SITE),
 # older versions did not.
@@ -28,21 +30,6 @@ def error_response(message):
     Return an error message to the server to be raised by the client.
     """
     return {"error": {"message": message}}
-
-
-def wrap_bytes_for_json(obj):
-    '''
-    JSON cannot (natively) encode bytes, so we provide a simple encoding for them.
-    This allows uniformity when using either JSON or binary formats (CBOR, etc.)
-    which do have native binary support. The JSON encoding is not meant to be
-    especially efficient, since anyone wanting seriously move around significant
-    amounts of binary data should use another format, but it provides a
-    consistent, readable/debuggable, fall-back.
-    '''
-    if isinstance(obj, bytes):
-        data = [int(v) for v in obj]
-        return {"bytes": data}
-    return obj
 
 
 def describe(registry, request):

--- a/py/preamble.py
+++ b/py/preamble.py
@@ -30,6 +30,21 @@ def error_response(message):
     return {"error": {"message": message}}
 
 
+def wrap_bytes_for_json(obj):
+    '''
+    JSON cannot (natively) encode bytes, so we provide a simple encoding for them.
+    This allows uniformity when using either JSON or binary formats (CBOR, etc.)
+    which do have native binary support. The JSON encoding is not meant to be
+    especially efficient, since anyone wanting seriously move around significant
+    amounts of binary data should use another format, but it provides a
+    consistent, readable/debuggable, fall-back.
+    '''
+    if isinstance(obj, bytes):
+        data = [int(v) for v in obj]
+        return {"bytes": data}
+    return obj
+
+
 def describe(registry, request):
     '''
     Tuber slow path

--- a/py/tuber/codecs.py
+++ b/py/tuber/codecs.py
@@ -1,0 +1,120 @@
+from collections.abc import Sequence
+import sys
+
+try:
+    import numpy
+    have_numpy = True
+except ImportError:
+    have_numpy = False
+    
+try:
+    import cbor2
+    have_cbor = True
+except ImportError:
+    have_cbor = False
+
+def wrap_bytes_for_json(obj):
+    '''
+    JSON cannot (natively) encode bytes, so we provide a simple encoding for them.
+    This allows uniformity when using either JSON or binary formats (CBOR, etc.)
+    which do have native binary support. The JSON encoding is not meant to be
+    especially efficient, since anyone wanting seriously move around significant
+    amounts of binary data should use another format, but it provides a
+    consistent, readable/debuggable, fall-back.
+    '''
+    if isinstance(obj, bytes):
+        data = [int(v) for v in obj]
+        return {"bytes": data}
+    return obj
+    
+    
+def cbor_encode_ndarray(enc, arr):
+    # At the moment, this handles only contiguous arrays of data types which can be represented
+    # as CBOR typed arrays, as these can be handled with a singleblock copy of the underlying data,
+    # with no per-element handling.
+
+    # start with big endian tags, and then patch up later if the data turn out to be little endian
+    type_tags = {
+        'u': {
+            1: 64,
+            2: 65,
+            4: 66,
+            8: 67,
+        },
+        'i': {
+            1: 72,
+            2: 73,
+            4: 74,
+            8: 75,
+        },
+        'f': {
+            2:  80,
+            4:  81,
+            8:  82,
+            16: 83,
+        },
+    }
+    if arr.dtype.kind not in type_tags or arr.dtype.itemsize not in type_tags[arr.dtype.kind]:
+        raise cbor2.CBOREncodeTypeError(f"Serialization of numpy arrays with element type {arr.dtype} is not implemented")
+    type_tag = type_tags[arr.dtype.kind][arr.dtype.itemsize]
+    # add 4 to type tag if little endian if sizeof(type) > 1
+    if arr.dtype.itemsize > 1 and (arr.dtype.byteorder == '<'
+          or (arr.dtype.byteorder == '=' and sys.byteorder == "little")):
+        type_tag += 4
+
+    if arr.flags.c_contiguous:
+        md_tag = 40  # row-major
+    elif arr.flags.f_contiguous:
+        md_tag = 1040  # column-major
+    else:
+        raise cbor2.CBOREncodeTypeError("Serialization of non-contiguous numpy arrays is not implemented")
+
+    enc.encode_length(6, md_tag) # multi-dimensional array header, a tag (type 6) of the correct type
+    enc.encode_length(4, 2) # payload of the m-d array is always an array (type 4) of length 2
+    enc.encode_length(4, len(arr.shape)) # the first item in the outer array is the array of extents
+    for extent in arr.shape:
+        enc.encode_int(extent)
+    # the second item in the outer array is the array entries, for which we use a typed array
+    enc.encode_length(6, type_tag)
+    # the typed array payload is a bytestring (type 2)
+    enc.encode_length(2, arr.nbytes)
+    # call write directly on the stream object to avoid unnecessary copies
+    enc.fp.write(arr.data)
+
+
+def cbor_augment_encode(enc, obj):
+    if isinstance(obj, numpy.ndarray):
+        cbor_encode_ndarray(enc, obj)
+        return
+    raise cbor2.CBOREncodeTypeError(f"Unsupported object for CBOR encoding {type(obj)}")
+
+
+def cbor_tag_decode(dec, tag):
+    if have_numpy and tag.tag>=64 and tag.tag<=87 and tag.tag!=76: # Typed arrays
+        is_float = tag.tag & 0x10
+        is_signed = tag.tag & 0x8
+        is_le = tag.tag & 0x4
+        ll = tag.tag & 0x3
+        element_size = 1<<ll
+        if is_float: # floats are one power of two larger
+            element_size <<= 1
+        # due to the cap of 87 on the tag, we will never see invalid 'signed' float combinations
+        dt = numpy.dtype(f"{'<' if is_le else '>'}{'f' if is_float else 'i' if is_signed else 'u'}{element_size}")
+        if len(tag.value) % element_size != 0:
+            raise cbor2.CBORDecodeValueError(f"Invalid data size ({len(tag.value)}) for typed array with tag {tag.tag}, interpreted as {dt}")
+        # create a 1-D, row-major array to contain all of the data, which can have more detailed
+        # shape and ordering information applied later
+        arr = numpy.zeros(len(tag.value) // element_size, dtype=dt, order='C')
+        # splat the data into the array's memory
+        arr.data.cast('B')[:] = tag.value
+        return arr
+    if have_numpy and (tag.tag == 40 or tag.tag == 1040):
+        if not isinstance(tag.value, Sequence):
+            raise cbor2.CBORDecodeValueError(f"Invalid raw data for multi-dimensional array tag ({tag.tag})")
+        if len(tag.value) != 2:
+            raise cbor2.CBORDecodeValueError(f"Invalid raw array length for multi-dimensional array tag ({tag.tag})")
+        if not isinstance(tag.value[0], Sequence) or not isinstance(tag.value[1], numpy.ndarray):
+            raise cbor2.CBORDecodeValueError(f"Invalid raw data for multi-dimensional array tag ({tag.tag})")
+        arr = tag.value[1].reshape(tag.value[0], order='C' if tag.tag == 40 else 'F')
+        return arr
+    return None

--- a/py/tuber/tuber.py
+++ b/py/tuber/tuber.py
@@ -7,10 +7,11 @@ import asyncio
 from collections.abc import Mapping
 import textwrap
 import types
+from typing import List, Dict, Tuple
 import warnings
 
 
-async def resolve(objname: str, hostname: str, accept_types: None):
+async def resolve(objname: str, hostname: str, accept_types: List[str] | None = None):
     """Create a local reference to a networked resource.
 
     This is the recommended way to connect to remote tuberd instances.
@@ -107,11 +108,11 @@ class Context(object):
     up to reduce roundtrips.
     """
 
-    def __init__(self, obj, accept_types: None, **ctx_kwargs):
-        self.calls = []
+    def __init__(self, obj: str, accept_types: List[str] | None = None, **ctx_kwargs):
+        self.calls: List[Tuple[Dict,asyncio.Future]] = []
         self.obj = obj
         if accept_types is None:
-            self.accept_types = AcceptTypes.keys()
+            self.accept_types = list(AcceptTypes.keys())
         else:
             for accept_type in accept_types:
                 if accept_type not in AcceptTypes.keys():
@@ -249,7 +250,7 @@ class TuberObject:
     To use it, you should subclass this TuberObject.
     """
 
-    def __init__(self, objname, uri, accept_types: None):
+    def __init__(self, objname: str, uri: str, accept_types: List[str] | None = None):
         self._tuber_objname = objname
         self._tuber_uri = uri
         self._accept_types = accept_types

--- a/py/tuber/tuber.py
+++ b/py/tuber/tuber.py
@@ -10,6 +10,8 @@ import types
 from typing import List, Dict, Tuple
 import warnings
 
+from .codecs import wrap_bytes_for_json, cbor_augment_encode, cbor_tag_decode
+
 
 async def resolve(objname: str, hostname: str, accept_types: List[str] | None = None):
     """Create a local reference to a networked resource.
@@ -77,7 +79,9 @@ AcceptTypes["application/json"] = decode_json
 try:
     import cbor2 as cbor
     def decode_cbor(response_data, encoding):
-        return cbor.loads(response_data, object_hook=lambda dec,data: TuberResult(data))
+        return cbor.loads(response_data,
+                          object_hook=lambda dec,data: TuberResult(data),
+                          tag_hook=cbor_tag_decode)
     AcceptTypes["application/cbor"] = decode_cbor
 except:
     pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytest
 requests
 aiohttp
 pytest-asyncio
+cbor2


### PR DESCRIPTION
The standard HTTP `Accept` header mechanism is used to negotiate the transport format between the client and server.
JSON is assumed to always be an option, while CBOR is used only if available. The `cbor2` module is used for CBOR support, since it seems to be actively maintained and has an interface nicely matching that of the built-in JSON module. 
A major benefit of allowing CBOR is to efficiently handle binary data, but uniform operation with JSON is important as well. To that end, a simple representation is added for the python `bytes` type when encoding to JSON, replacing it with a dictionary containing a key `"bytes"` which maps to a list of integers containing the byte values. This is chosen to match the [encoding used by nlohmann/json](https://json.nlohmann.me/features/binary_values/#json). The client it also extended to recognize this structure in JSON data and synthesize it back into a `bytes` object (also permitting, but currently ignoring the `"subtype"` key in case this might be used for compatibility with formats which have binary subtypes). 