### PR TITLE
Teach setuptools to compile tuberd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 CMakeFiles/
 CMakeCache.txt
+CTestTestfile.cmake
+DartConfiguration.tcl
+Testing/
 Makefile
 build/
 dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,29 @@
+[build-system]
+requires = [
+    "cmake>=3.12",
+    "pybind11",
+    "setuptools>=42",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name='tuber'
+description='Serve Python (or C++) objects across a LAN using something like JSON-RPC'
+version='0.10'
+authors=[
+	{name="Graeme Smecher", email="gsmecher@threespeedlogic.com"},
+]
+urls={source="https://github.com/gsmecher/tuber"}
+classifiers=[
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+]
+license = {file="LICENSE"}
+
+[options]
+package_dir={tuber="py"}
+
 [tool.black]
 line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -3,18 +3,74 @@
 
 from setuptools import setup
 
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
+from setuptools.command.install_scripts import install_scripts
+
+# Convert distutils platform specifiers to CMake -A arguments
+PLAT_TO_CMAKE = {
+    "linux-x86_64": "x64",
+}
+
+
+# A CMakeExtension needs a sourcedir instead of a file list.
+# The name must be the _single_ output extension from the CMake build.
+# If you need multiple extensions, see scikit-build.
+class CMakeExtension(Extension):
+    def __init__(self, name: str, sourcedir: str = "") -> None:
+        super().__init__(name, sources=[], optional=True)
+        self.sourcedir = os.fspath(Path(sourcedir).resolve())
+
+
+class CMakeBuild(build_ext):
+    def build_extension(self, ext: CMakeExtension) -> None:
+        if (sys.platform != "linux") and (not sys.platform.startswith("darwin")):
+            raise DistutilsPlatformError("Cannot compile tuberd on non-Linux platform!")
+
+        # Must be in this form due to bug in .resolve() only fixed in Python 3.10+
+        ext_fullpath = Path.cwd() / self.get_ext_fullpath(ext.name)
+        extdir = ext_fullpath.parent.resolve()
+
+        cmake_args = []
+        build_args = []
+
+        # Adding CMake arguments set as environment variable
+        if "CMAKE_ARGS" in os.environ:
+            cmake_args += [item for item in os.environ["CMAKE_ARGS"].split(" ") if item]
+
+        build_temp = Path(self.build_temp) / ext.name
+        if not build_temp.exists():
+            build_temp.mkdir(parents=True)
+
+        subprocess.run(["cmake", ext.sourcedir, *cmake_args], cwd=build_temp, check=True)
+        subprocess.run(["cmake", "--build", ".", *build_args], cwd=build_temp, check=True)
+        self.tuberd_path = build_temp / "tuberd"
+
+
+class CMakeInstall(install_scripts):
+    def run(self):
+        self.announce("Installing tuberd", level=3)
+
+        install_dir = Path(self.install_dir)
+        if not install_dir.exists():
+            install_dir.mkdir(parents=True)
+
+        tuberd_src = self.get_finalized_command("build_ext").tuberd_path
+        tuberd_dst = install_dir / "tuberd"
+        self.copy_file(tuberd_src, tuberd_dst)
+        super().run()
+
+
 setup(
-    name="tuber",
-    version="0.10",
-    author="Graeme Smecher",
-    author_email="gsmecher@threespeedlogic.com",
-    description="Serve Python (or C++) objects across a LAN using something like JSON-RPC",
-    url="https://github.com/gsmecher/tuber",
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Operating System :: OS Independent",
-    ],
-    packages=["tuber"],
-    package_dir={"": "py"},
+    ext_modules=[CMakeExtension("tuberd")],
+    cmdclass={
+        "build_ext": CMakeBuild,
+        "install_scripts": CMakeInstall,
+    },
 )


### PR DESCRIPTION
Instead of using separate install flows for the server (tuberd) and client (tuber) code, use Python's setup machinery for both.

In practice, this means teaching Python to compile cmake packages. There is a pybind11 example package I've bent into shape for this.