### PR TITLE
tuberd: allow "import tuber" to fail in client-side code

### DIFF
--- a/py/tuber/__init__.py
+++ b/py/tuber/__init__.py
@@ -1,6 +1,3 @@
-import os
-
-
 class TuberError(Exception):
     pass
 
@@ -30,8 +27,10 @@ try:
 
     __all__ += ["TuberObject", "resolve"]
 except ImportError as ie:
+    import os
+
     if "TUBER_SERVER" not in os.environ:
-        raise e
+        raise ie
 
 
 # vim: sts=4 ts=4 sw=4 tw=78 smarttab expandtab

--- a/py/tuber/__init__.py
+++ b/py/tuber/__init__.py
@@ -1,11 +1,37 @@
-from .tuber import (
-    TuberError,
-    TuberStateError,
-    TuberRemoteError,
-    TuberObject,
-    resolve,
-)
+import os
 
-__all__ = ["TuberError", "TuberRemoteError", "TuberObject", "resolve"]
+
+class TuberError(Exception):
+    pass
+
+
+class TuberStateError(TuberError):
+    pass
+
+
+class TuberRemoteError(TuberError):
+    pass
+
+
+__all__ = [
+    "TuberError",
+    "TuberRemoteError",
+    "TuberStateError",
+]
+
+# The tuber module is imported in both server and client environments. Because
+# the server execution environment may be minimal, we may bump into
+# ModuleNotFoundErrors in client code - which we may want to ignore.
+try:
+    from .client import (
+        TuberObject,
+        resolve,
+    )
+
+    __all__ += ["TuberObject", "resolve"]
+except ImportError as ie:
+    if "TUBER_SERVER" not in os.environ:
+        raise e
+
 
 # vim: sts=4 ts=4 sw=4 tw=78 smarttab expandtab

--- a/py/tuber/client.py
+++ b/py/tuber/client.py
@@ -10,6 +10,7 @@ import types
 from typing import List, Dict, Tuple
 import warnings
 
+from . import TuberError, TuberStateError, TuberRemoteError
 from .codecs import wrap_bytes_for_json, cbor_augment_encode, cbor_tag_decode
 
 
@@ -22,18 +23,6 @@ async def resolve(objname: str, hostname: str, accept_types: List[str] | None = 
     instance = TuberObject(objname, f"http://{hostname}/tuber", accept_types=accept_types)
     await instance.tuber_resolve()
     return instance
-
-
-class TuberError(Exception):
-    pass
-
-
-class TuberStateError(TuberError):
-    pass
-
-
-class TuberRemoteError(TuberError):
-    pass
 
 
 class TuberResult:

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -533,6 +533,8 @@ int main(int argc, char **argv) {
 	 * Initialize Python runtime
 	 */
 
+	/* Indicate to anyone who cares that we're running server-side */
+	setenv("TUBER_SERVER", "1", 1);
 	py::scoped_interpreter python;
 
 	/* By default, capture warnings */


### PR DESCRIPTION
In a resource-constrained server environment, some Python packages (aiohttp) may not be present. These modules are used in client-side tuber code and don't need to work anyway.

This PR breaks the dependence on client-side API code when running in a server-side environment.