### PR TITLE
Moves preamble.py into tuber.server

### DIFF
--- a/py/tuber/client.py
+++ b/py/tuber/client.py
@@ -118,6 +118,7 @@ class Context(object):
     def __init__(
         self,
         obj: "TuberObject" | None = None,
+        *,
         uri: str | None = None,
         accept_types: list[str] | None = None,
         **ctx_kwargs,

--- a/py/tuber/server.py
+++ b/py/tuber/server.py
@@ -1,20 +1,6 @@
 import inspect
-import sys
-import os
-import sysconfig
-import site
 
-from tuber.codecs import wrap_bytes_for_json, cbor_augment_encode, cbor_tag_decode
-
-
-# Although upstream pybind11 allows user sites (check site.ENABLE_USER_SITE),
-# older versions did not.
-ver = sysconfig.get_python_version()
-sys.path.append(os.path.expanduser(f"~/.local/lib/python{ver}/site-packages"))
-
-# Similarly, the working directory is a reasonable expectation not met by some
-# versions of pybind11.
-sys.path.append(".")
+from .codecs import wrap_bytes_for_json, cbor_augment_encode, cbor_tag_decode
 
 
 def result_response(arg=None, **kwargs):

--- a/tests/test.py
+++ b/tests/test.py
@@ -124,13 +124,11 @@ def tuberd(pytestconfig):
     src_dir = pathlib.Path(os.environ.get("CMAKE_SOURCE_DIR", "."))
 
     tuberd = bin_dir / "tuberd"
-    preamble = src_dir / "py/preamble.py"
     registry = src_dir / "tests/test.py"
 
     argv = [
         f"{tuberd}",
         f"-p{TUBERD_PORT}",
-        f"--preamble={preamble}",
         f"--registry={registry}",
     ]
 


### PR DESCRIPTION
There is no longer a "--preamble" argument to tuberd.