### PR TITLE
Create attributes for all remote methods and properties on resolve

### DIFF
--- a/py/tuber/client.py
+++ b/py/tuber/client.py
@@ -282,7 +282,8 @@ class TuberObject:
 
         Overload this method to create child objects using different subclasses.
         """
-
+        if self._tuber_objname is not None:
+            raise NotImplementedError
         return TuberObject(objname, uri=self._tuber_uri, accept_types=self._accept_types)
 
     @property

--- a/tests/test.py
+++ b/tests/test.py
@@ -556,7 +556,8 @@ async def test_tuberpy_warnings(tuber_call, accept_types):
 @pytest.mark.parametrize("accept_types", ACCEPT_TYPES)
 @pytest.mark.asyncio
 async def test_tuberpy_resolve_all(tuber_call, accept_types):
-    """Ensure resolve_all finds all registry entries"""
+    """Ensure resolve finds all registry entries"""
     s = await tuber.resolve(TUBERD_HOSTNAME, accept_types=accept_types)
 
     assert set(dir(s)) >= set(registry)
+    assert set(dir(s.Types)) >= set(dir(registry["Types"]))


### PR DESCRIPTION
This requires that `resolve()` or `TuberObject.tuber_resolve()` be called at the start of a script, rather than lazy-loading methods and properties on access.