### PR TITLE
Child context attributes

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -559,3 +559,19 @@ async def test_tuberpy_resolve_all(tuber_call, accept_types):
 
     assert set(dir(s)) >= set(registry)
     assert set(dir(s.Types)) >= set(dir(registry["Types"]))
+
+
+@pytest.mark.parametrize("accept_types", ACCEPT_TYPES)
+@pytest.mark.asyncio
+async def test_tuberpy_registry_context(tuber_call, accept_types):
+    """Ensure registry entries are accessible from top level context"""
+
+    s = await tuber.resolve(TUBERD_HOSTNAME, accept_types=accept_types)
+
+    async with s.tuber_context() as ctx:
+        ctx.Wrapper.increment(x=[1, 2, 3])
+        ctx.Types.integer_function()
+        r1, r2 = await ctx()
+
+    assert r1 == [2, 3, 4]
+    assert r2 == Types.INTEGER

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -127,6 +127,8 @@ class Context(object):
             self.calls: list[tuple[dict, asyncio.Future]] = []
             self.uri = self.obj._tuber_uri
             if accept_types is None:
+                accept_types = self.obj._accept_types
+            if accept_types is None:
                 self.accept_types = list(AcceptTypes.keys())
             else:
                 for accept_type in accept_types:
@@ -303,7 +305,7 @@ class TuberObject:
         latter to succeed."""
         if objname is not None and self._tuber_objname is not None:
             raise NotImplementedError
-        ctx = Context(self, accept_types=self._accept_types, **kwargs)
+        ctx = Context(self, **kwargs)
         if objname is not None:
             return getattr(ctx, objname)
         return ctx


### PR DESCRIPTION
Attributes of Context objects that are themselves TuberObject attributes of the input object now resolve as Context objects whose call interface remains that of the parent Context.  This allows communicating with multiple registry objects in a single Context block.  For example, the following will call methods of two different registry entries (attr1 and attr2) on the remote with a single network interaction:

    async with obj.tuber_context() as ctx:
        ctx.attr1.function1()
        ctx.attr2.function2()
        await ctx()