### PR TITLE
Simple tuber client

### DIFF
--- a/tuber/__init__.py
+++ b/tuber/__init__.py
@@ -28,10 +28,12 @@ except ImportError:
 try:
     from .client import (
         TuberObject,
+        SimpleTuberObject,
         resolve,
+        resolve_simple,
     )
 
-    __all__ += ["TuberObject", "resolve"]
+    __all__ += ["TuberObject", "SimpleTuberObject", "resolve", "resolve_simple"]
 except ImportError as ie:
     import os
 


### PR DESCRIPTION
Implement a SimpleTuberClient class, with a corresponding SimpleContext.  The API is similar to that of the asynchronous TuberClient, but all methods are called serially.  The context object still enables pooling multiple method calls into a single HTTP request as usual.

The asynchronous client object is now a subclass of the simple class, with the asynchronous methods (e.g. tuber_resolve) overloaded appropriately.