### PR TITLE
Optionally allow errors in a sequence of remote commands

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -315,9 +315,9 @@ class DLL_LOCAL tuber_resource : public http_resource {
 				}
 
 				auto xopts = parseCommaSepList(req.get_header("X-Tuber-Options"));
-				bool no_early_bail = false;
+				bool continue_on_error = false;
 				if (xopts.size() > 0) {
-					no_early_bail = std::find(xopts.begin(), xopts.end(), "continue-on-error") != xopts.end();
+					continue_on_error = std::find(xopts.begin(), xopts.end(), "continue-on-error") != xopts.end();
 				}
 
 				/* Parse request */
@@ -358,11 +358,11 @@ class DLL_LOCAL tuber_resource : public http_resource {
 						} catch(std::exception &e) {
 							/* Indicates an internal error - this does not normally happen */
 							result[i] = error_response(e.what());
-							if (!no_early_bail)
+							if (!continue_on_error)
 								early_bail = true;
 						}
 
-						if(result[i].contains("error") && !no_early_bail) {
+						if(result[i].contains("error") && !continue_on_error) {
 							/* Indicates client code flagged an error - this is a nominal code path */
 							early_bail = true;
 						}

--- a/tests/test.py
+++ b/tests/test.py
@@ -677,20 +677,41 @@ async def test_tuberpy_fake_async(tuber_call, accept_types, simple):
     assert r2 == Types.INTEGER
 
 
+@pytest.mark.parametrize("continue_on_error", [True, False])
 @pytest.mark.parametrize("simple", [True, False])
 @pytest.mark.parametrize("accept_types", ACCEPT_TYPES)
 @pytest.mark.asyncio
-async def test_tuberpy_noerr(tuber_call, accept_types, simple):
+async def test_tuberpy_continue_errors(tuber_call, accept_types, simple, continue_on_error):
     """Ensure errors are turned into warnings"""
-    s = await resolve("Warnings", accept_types, simple)
+    s = await resolve(accept_types=accept_types, simple=simple)
 
-    with pytest.warns(match="This is a warning"), pytest.warns(match="Oops!"):
+    with pytest.warns(match="This is a warning"):
         if simple:
             with s.tuber_context() as ctx:
-                ctx.single_warning("This is a warning", error=True)
-                ctx(warn_remote_errors=True)
-
+                ctx.Wrapper.increment([1, 2, 3])  # fine
+                ctx.Warnings.single_warning("This is a warning", error=True)
+                ctx.Wrapper.increment([5, 6, 6])  # should still execute
+                if not continue_on_error:
+                    with pytest.raises(tuber.TuberRemoteError):
+                        ctx()
+                else:
+                    r1, r2, r3 = ctx(continue_on_error=True)
         else:
             async with s.tuber_context() as ctx:
-                ctx.single_warning("This is a warning", error=True)
-                await ctx(warn_remote_errors=True)
+                ctx.Wrapper.increment([1, 2, 3])  # fine
+                ctx.Warnings.single_warning("This is a warning", error=True)
+                r3 = ctx.Wrapper.increment([5, 6, 6])  # should still execute
+                if not continue_on_error:
+                    with pytest.raises(tuber.TuberRemoteError):
+                        await ctx()
+                    with pytest.raises(tuber.TuberRemoteError):
+                        await r3
+                else:
+                    r1, r2, r3 = await ctx(continue_on_error=True)
+
+    if not continue_on_error:
+        return
+
+    assert r1 == [2, 3, 4]
+    assert r2.error  # this is an error response returned as a result
+    assert r3 == [6, 7, 7]

--- a/tests/test.py
+++ b/tests/test.py
@@ -655,3 +655,22 @@ async def test_tuberpy_registry_context(tuber_call, accept_types, simple):
 
     assert r1 == [2, 3, 4]
     assert r2 == Types.INTEGER
+
+
+@pytest.mark.parametrize("simple", [True, False])
+@pytest.mark.parametrize("accept_types", ACCEPT_TYPES)
+@pytest.mark.asyncio
+async def test_tuberpy_noerr(tuber_call, accept_types, simple):
+    """Ensure errors are turned into warnings"""
+    s = await resolve("Warnings", accept_types, simple)
+
+    with pytest.warns(match="This is a warning"), pytest.warns(match="Oops!"):
+        if simple:
+            with s.tuber_context() as ctx:
+                ctx.single_warning("This is a warning", error=True)
+                ctx(warn_remote_errors=True)
+
+        else:
+            async with s.tuber_context() as ctx:
+                ctx.single_warning("This is a warning", error=True)
+                await ctx(warn_remote_errors=True)

--- a/tests/test.py
+++ b/tests/test.py
@@ -698,8 +698,8 @@ async def test_tuberpy_continue_errors(tuber_call, accept_types, simple, continu
                     r1, r2, r3 = ctx(continue_on_error=True)
         else:
             async with s.tuber_context() as ctx:
-                ctx.Wrapper.increment([1, 2, 3])  # fine
-                ctx.Warnings.single_warning("This is a warning", error=True)
+                r1 = ctx.Wrapper.increment([1, 2, 3])  # fine
+                r2 = ctx.Warnings.single_warning("This is a warning", error=True)
                 r3 = ctx.Wrapper.increment([5, 6, 6])  # should still execute
                 if not continue_on_error:
                     with pytest.raises(tuber.TuberRemoteError):
@@ -707,11 +707,19 @@ async def test_tuberpy_continue_errors(tuber_call, accept_types, simple, continu
                     with pytest.raises(tuber.TuberRemoteError):
                         await r3
                 else:
-                    r1, r2, r3 = await ctx(continue_on_error=True)
+                    try:
+                        await ctx(continue_on_error=True)
+                    except tuber.TuberRemoteError:
+                        pass
+                    with pytest.raises(tuber.TuberRemoteError):
+                        await r2
+                    r1 = await r1
+                    r3 = await r3
 
     if not continue_on_error:
         return
 
     assert r1 == [2, 3, 4]
-    assert r2.error  # this is an error response returned as a result
+    if simple:
+        assert isinstance(r2, tuber.TuberRemoteError)  # this is an error response returned as a result
     assert r3 == [6, 7, 7]

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -220,10 +220,11 @@ class SimpleContext:
 
             # Resolve either a result or an error
             if hasattr(r, "error") and r.error:
+                exc = TuberRemoteError(getattr(r.error, "message", "Unknown error"))
                 if continue_on_error:
-                    results.append(r)
+                    results.append(exc)
                 else:
-                    raise TuberRemoteError(getattr(r.error, "message", "Unknown error"))
+                    raise exc
             elif hasattr(r, "result"):
                 results.append(r.result)
             else:
@@ -349,10 +350,10 @@ class Context(SimpleContext):
 
             # Resolve either a result or an error
             if hasattr(r, "error") and r.error:
-                if continue_on_error:
-                    f.set_result(r)
+                if hasattr(r.error, "message"):
+                    f.set_exception(TuberRemoteError(r.error.message))
                 else:
-                    f.set_exception(TuberRemoteError(getattr(r.error, "message", "Unknown error")))
+                    f.set_exception(TuberRemoteError("Unknown error"))
             else:
                 if hasattr(r, "result"):
                     f.set_result(r.result)


### PR DESCRIPTION
Optionally return a result with an error attribute, instead of raising an error, to ensure that all commands in a batch are executed.